### PR TITLE
feat(deploy): chain admin-funding tx-00 to MPT-migration; eliminate two-phase deploy (P2b)

### DIFF
--- a/scripts/generateDeploymentPlan.ts
+++ b/scripts/generateDeploymentPlan.ts
@@ -141,7 +141,92 @@ const main = async () => {
   // Track consumed UTxOs across all txs to prevent input conflicts
   const consumedUtxoRefs = new Set<string>();
 
+  // Determine whether the MPT-root migration tx will need to be emitted.
+  // We compute this UP FRONT so the admin-funding tx (if needed) can be
+  // emitted as tx-00 — the operator signs+submits it first, the
+  // migration tx then references its predicted outputs as inputs, and
+  // the whole chain ships in one workflow run instead of the historical
+  // two-phase pattern.
+  const mptContract = plan.summaryJson.contracts.find(
+    (c) => c.contract_slug === "demimntmpt"
+  );
+  const mptNeedsMigration = await (async () => {
+    if (!mptContract || !blockfrostApiKey) return false;
+    if (mptContract.drift_type === "script_hash_only" || mptContract.drift_type === "script_hash_and_settings") return true;
+    try {
+      const { fetch: crossFetch } = await import("cross-fetch");
+      const baseUrl = desired.network === "preview" ? "https://preview.api.handle.me" :
+        desired.network === "preprod" ? "https://preprod.api.handle.me" : "https://api.handle.me";
+      const rootRes = await crossFetch(`${baseUrl}/handles/${encodeURIComponent("handle_root@handle_settings")}`,
+        { headers: { "User-Agent": userAgent } });
+      if (!rootRes.ok) return false;
+      const rootHandle = await rootRes.json() as { resolved_addresses?: { ada?: string } };
+      const currentAddress = rootHandle.resolved_addresses?.ada ?? "";
+      const latestSub = mptContract.subhandle?.value ?? "";
+      if (!latestSub) return false;
+      const subRes = await crossFetch(`${baseUrl}/handles/${encodeURIComponent(latestSub)}`,
+        { headers: { "User-Agent": userAgent } });
+      if (!subRes.ok) return false;
+      const subHandle = await subRes.json() as { resolved_addresses?: { ada?: string } };
+      void subHandle;
+      const { buildContracts } = await import("../src/contracts/config.js");
+      const built = buildContracts({
+        network: desired.network,
+        mint_version: BigInt(desired.buildParameters.mintVersion),
+        legacy_policy_id: desired.buildParameters.legacyPolicyId,
+        admin_verification_key_hash: desired.buildParameters.adminVerificationKeyHash,
+      });
+      const expectedAddress = built.mintingData.mintingDataValidatorAddress.toBech32();
+      const needsMigration = currentAddress !== expectedAddress;
+      if (needsMigration) {
+        console.log(`handle_root@handle_settings is at ${currentAddress.slice(0, 30)}... but should be at ${expectedAddress.slice(0, 30)}...`);
+      }
+      return needsMigration;
+    } catch {
+      return false;
+    }
+  })();
+
+  // If migration is needed, build the admin-funding tx FIRST (as
+  // tx-00) and capture the predicted outputs that the migration tx
+  // will consume. `buildPreparationTx` returns null when admin
+  // already has both a collateral-sized and a fee-sized clean ADA
+  // UTxO on chain — in that case no funding tx is emitted.
   let txIndex = 0;
+  let pendingAdminFunding: Awaited<ReturnType<typeof buildPreparationTx>> = null;
+  if (mptNeedsMigration && blockfrostApiKey) {
+    try {
+      pendingAdminFunding = await buildPreparationTx({
+        desired,
+        nativeScriptCborHex: nativeScriptCborHex || undefined,
+        blockfrostApiKey,
+        userAgent,
+        excludeUtxoRefs: consumedUtxoRefs,
+      });
+      if (pendingAdminFunding) {
+        for (const ref of pendingAdminFunding.consumedInputs) consumedUtxoRefs.add(ref);
+        // tx-00 is reserved for the funding tx — every subsequent
+        // deploy/settings/migration tx in this run is numbered
+        // starting at tx-01. Naming pattern matches the historical
+        // tx-04-admin-funding emission so K.O.R.A. and operator
+        // muscle memory recognize it.
+        const prepFileName = `tx-${String(txIndex).padStart(2, "0")}-admin-funding.cbor`;
+        const prepCborBytes = Buffer.from(pendingAdminFunding.cborHex, "hex");
+        await fs.writeFile(path.join(args["artifacts-dir"], prepFileName), prepCborBytes);
+        await fs.writeFile(path.join(args["artifacts-dir"], `${prepFileName}.hex`), `${pendingAdminFunding.cborHex}\n`);
+        generatedArtifacts.push(prepFileName, `${prepFileName}.hex`);
+        transactionOrder.push(prepFileName);
+        txArtifactGenerated = true;
+        console.log(`Generated admin funding tx: ${prepFileName} (sign + submit FIRST; migration tx references its predicted outputs)`);
+        // Leave txIndex at 0 — the loop below increments BEFORE
+        // formatting the filename, so the first deploy tx will be
+        // tx-01 even though we just wrote tx-00.
+      }
+    } catch (error) {
+      console.log(`Skipping admin funding tx: ${error instanceof Error ? error.message : error}`);
+    }
+  }
+
   for (const contractPlan of changedContracts) {
     const desiredContract = desired.contracts.find((contract) => contract.contractSlug === contractPlan.contract_slug);
     const handleName = String(contractPlan.subhandle.value ?? "").trim();
@@ -202,83 +287,18 @@ const main = async () => {
     }
   }
 
-  // Generate MPT root migration tx if handle_root@handle_settings is at the wrong address.
-  // This can happen after a demimntmpt upgrade — the ref script is deployed but the
-  // handle_root UTxO still sits at the old validator address.
-  const mptContract = plan.summaryJson.contracts.find(
-    (c) => c.contract_slug === "demimntmpt"
-  );
-  const mptNeedsMigration = await (async () => {
-    if (!mptContract || !blockfrostApiKey) return false;
-    // If there's a script hash change, migration is always needed
-    if (mptContract.drift_type === "script_hash_only" || mptContract.drift_type === "script_hash_and_settings") return true;
-    // Check if handle_root@handle_settings is at the expected validator address
-    try {
-      const { fetch: crossFetch } = await import("cross-fetch");
-      const baseUrl = desired.network === "preview" ? "https://preview.api.handle.me" :
-        desired.network === "preprod" ? "https://preprod.api.handle.me" : "https://api.handle.me";
-      const rootRes = await crossFetch(`${baseUrl}/handles/${encodeURIComponent("handle_root@handle_settings")}`,
-        { headers: { "User-Agent": userAgent } });
-      if (!rootRes.ok) return false;
-      const rootHandle = await rootRes.json() as { resolved_addresses?: { ada?: string } };
-      const currentAddress = rootHandle.resolved_addresses?.ada ?? "";
-      // Get the expected address from the latest demimntmpt subhandle
-      const latestSub = mptContract.subhandle?.value ?? "";
-      if (!latestSub) return false;
-      const subRes = await crossFetch(`${baseUrl}/handles/${encodeURIComponent(latestSub)}`,
-        { headers: { "User-Agent": userAgent } });
-      if (!subRes.ok) return false;
-      const subHandle = await subRes.json() as { resolved_addresses?: { ada?: string } };
-      const expectedScriptAddress = subHandle.resolved_addresses?.ada ?? "";
-      // The handle_root should be at the validator address derived from the latest script hash,
-      // NOT at the subhandle's address. Compute expected from the built contracts.
-      const { buildContracts } = await import("../src/contracts/config.js");
-      const built = buildContracts({
-        network: desired.network,
-        mint_version: BigInt(desired.buildParameters.mintVersion),
-        legacy_policy_id: desired.buildParameters.legacyPolicyId,
-        admin_verification_key_hash: desired.buildParameters.adminVerificationKeyHash,
-      });
-      const expectedAddress = built.mintingData.mintingDataValidatorAddress.toBech32();
-      const needsMigration = currentAddress !== expectedAddress;
-      if (needsMigration) {
-        console.log(`handle_root@handle_settings is at ${currentAddress.slice(0, 30)}... but should be at ${expectedAddress.slice(0, 30)}...`);
-      }
-      return needsMigration;
-    } catch {
-      return false;
-    }
-  })();
+  // Emit the MPT-root migration tx (last in the manifest). When
+  // `pendingAdminFunding` is set, the migration tx references the
+  // funding tx's predicted outputs as inputs — operator signs both,
+  // submits in order (tx-00 → migration), node accepts the chain.
   if (mptNeedsMigration) {
     const currentMptSubhandle = liveContracts.find(
       (lc) => lc.contractSlug === "demimntmpt"
     )?.currentSubhandle;
-
     if (!currentMptSubhandle) {
       console.log("Skipping MPT root migration: no current demimntmpt subhandle found");
     } else {
       try {
-        // Check if admin wallet needs funding and generate a prep tx
-        const prepTx = await buildPreparationTx({
-          desired,
-          nativeScriptCborHex: nativeScriptCborHex || undefined,
-          blockfrostApiKey,
-          userAgent,
-          excludeUtxoRefs: consumedUtxoRefs,
-        });
-        if (prepTx) {
-          for (const ref of prepTx.consumedInputs) consumedUtxoRefs.add(ref);
-          txIndex += 1;
-          const prepFileName = `tx-${String(txIndex).padStart(2, "0")}-admin-funding.cbor`;
-          const prepCborBytes = Buffer.from(prepTx.cborHex, "hex");
-          await fs.writeFile(path.join(args["artifacts-dir"], prepFileName), prepCborBytes);
-          await fs.writeFile(path.join(args["artifacts-dir"], `${prepFileName}.hex`), `${prepTx.cborHex}\n`);
-          generatedArtifacts.push(prepFileName, `${prepFileName}.hex`);
-          transactionOrder.push(prepFileName);
-          txArtifactGenerated = true;
-          console.log(`Generated admin funding tx: ${prepFileName} (sign and submit before MPT migration)`);
-        }
-
         console.log("Computing MPT root hash from API handle set...");
         const newMptRootHash = await computeMptRootHash({
           network: desired.network,
@@ -293,31 +313,27 @@ const main = async () => {
           userAgent,
         });
 
-        try {
-          const migrationTx = await buildMptRootMigrationTx({
-            desired,
-            newMptRootHash,
-            oldValidatorCborHex,
-            blockfrostApiKey,
-            userAgent,
-          });
+        const migrationTx = await buildMptRootMigrationTx({
+          desired,
+          newMptRootHash,
+          oldValidatorCborHex,
+          blockfrostApiKey,
+          userAgent,
+          pendingAdminFunding: pendingAdminFunding?.pendingAdminFundingUtxos,
+        });
 
-          txIndex += 1;
-          const fileName = `tx-${String(txIndex).padStart(2, "0")}-mpt-migration.cbor`;
-          const cborBytes = Buffer.from(migrationTx.cborHex, "hex");
-          await fs.writeFile(path.join(args["artifacts-dir"], fileName), cborBytes);
-          await fs.writeFile(path.join(args["artifacts-dir"], `${fileName}.hex`), `${migrationTx.cborHex}\n`);
-          generatedArtifacts.push(fileName, `${fileName}.hex`);
-          transactionOrder.push(fileName);
-          txArtifactGenerated = true;
-          console.log(`Generated MPT root migration tx: ${fileName} (requires admin/policy key signature)`);
-        } catch (migrationError) {
-          if (prepTx) {
-            console.log(`MPT root migration tx deferred: admin funding tx must be submitted first, then re-run this workflow`);
-          } else {
-            throw migrationError;
-          }
-        }
+        txIndex += 1;
+        const fileName = `tx-${String(txIndex).padStart(2, "0")}-mpt-migration.cbor`;
+        const cborBytes = Buffer.from(migrationTx.cborHex, "hex");
+        await fs.writeFile(path.join(args["artifacts-dir"], fileName), cborBytes);
+        await fs.writeFile(path.join(args["artifacts-dir"], `${fileName}.hex`), `${migrationTx.cborHex}\n`);
+        generatedArtifacts.push(fileName, `${fileName}.hex`);
+        transactionOrder.push(fileName);
+        txArtifactGenerated = true;
+        const chainNote = pendingAdminFunding
+          ? " (chained — references admin-funding tx-00 outputs; submit tx-00 first)"
+          : " (admin already funded; no chained inputs)";
+        console.log(`Generated MPT root migration tx: ${fileName} (requires admin/policy key signature)${chainNote}`);
       } catch (error) {
         console.log(`Skipping MPT root migration tx: ${error instanceof Error ? error.message : error}`);
       }

--- a/src/deploymentTx.ts
+++ b/src/deploymentTx.ts
@@ -46,6 +46,15 @@ export interface BuiltTransaction {
   estimatedSignedTxSize: number;
   /** UTxO refs consumed as inputs (txHash#index), for excluding from subsequent txs */
   consumedInputs: Set<string>;
+  /**
+   * The body-hash / txId of the unsigned tx. Deterministic from the body —
+   * does NOT change when the operator adds signatures in Eternl. Lets a
+   * later tx in the same plan reference an output of this one even before
+   * this tx has confirmed on chain (chained-tx pattern, used by
+   * `buildMptRootMigrationTx` to reference the predicted admin-funding
+   * outputs without waiting for them to land).
+   */
+  txHash: string;
 }
 
 export const resolveDeployerWallet = async ({
@@ -570,31 +579,67 @@ const buildAndSerializeTx = async ({
     consumedInputs.add(toUtxoRef(utxo));
   }
 
-  return { cborHex, estimatedSignedTxSize, consumedInputs };
+  // Body-hash / txId from `unsignedTx.id` (set above to
+  // `finalTxBodyWithHash.hash`). String form so callers can build
+  // chained-input references without depending on cardano-sdk's
+  // TransactionId type.
+  const txHash = String(unsignedTx.id);
+
+  return { cborHex, estimatedSignedTxSize, consumedInputs, txHash };
 };
 
 /**
+ * Predicted UTxOs that an unsubmitted `buildPreparationTx` output will
+ * create at the admin address once it lands. Lets the migration tx that
+ * follows in the same plan reference these inputs without waiting for
+ * the funding tx to confirm — the operator signs both, submits in
+ * order, and the node accepts the chain.
+ */
+export interface PendingAdminFundingUtxos {
+  /** Pure-ADA UTxO sized for collateral (≥ minCollateralPercentage% of fee). */
+  collateralUtxo: CardanoTypes.Utxo;
+  /** Pure-ADA UTxO sized to cover the migration tx's fee + change. */
+  feeUtxo: CardanoTypes.Utxo;
+}
+
+export interface PreparationTx extends BuiltTransaction {
+  /**
+   * The two outputs this funding tx creates at the admin address — one
+   * sized for collateral, one sized for fee. Pass into
+   * `buildMptRootMigrationTx` via its `pendingAdminFunding` param so
+   * the migration tx references these unconfirmed UTxOs directly,
+   * eliminating the two-phase deploy.
+   */
+  pendingAdminFundingUtxos: PendingAdminFundingUtxos;
+}
+
+const COLLATERAL_OUTPUT_LOVELACE = 6_000_000n;
+const FEE_OUTPUT_LOVELACE = 4_000_000n;
+
+/**
  * Build an unsigned preparation tx that funds the admin address from the
- * script address. This is needed when the admin wallet has insufficient ADA
- * for the MPT root migration tx (which requires fees + collateral).
+ * script address. Always emits TWO outputs at admin — one sized for
+ * collateral (6 ADA), one for fee + change (4 ADA) — so the migration
+ * tx that follows can reference them as separate inputs (collateral and
+ * regular input slots cannot share a UTxO).
  *
- * Returns null if the admin address already has enough funds.
+ * Returns null if the admin address already has BOTH a collateral-
+ * sized UTxO and a fee-sized UTxO on chain — in that case no funding
+ * is needed and the migration tx can use admin's existing UTxOs.
  */
 export const buildPreparationTx = async ({
   desired,
   nativeScriptCborHex,
   blockfrostApiKey,
   userAgent,
-  targetLovelace = 10_000_000n,
   excludeUtxoRefs,
 }: {
   desired: DesiredDeploymentState;
   nativeScriptCborHex?: string;
   blockfrostApiKey: string;
   userAgent: string;
-  targetLovelace?: bigint;
   excludeUtxoRefs?: Set<string>;
-}): Promise<BuiltTransaction | null> => {
+}): Promise<PreparationTx | null> => {
   const isMainnet = desired.network === "mainnet";
   const adminKeyHash = desired.buildParameters.adminVerificationKeyHash;
   const adminCredential = {
@@ -613,16 +658,22 @@ export const buildPreparationTx = async ({
     blockfrostApiKey,
     desired.network,
   );
-  const adminBalance = adminUtxos.reduce(
-    (sum, u) => sum + (u[1].value.coins ?? 0n),
-    0n,
-  );
-
-  if (adminBalance >= targetLovelace) {
+  // Funding is unnecessary only when admin already has BOTH a clean
+  // ADA-only UTxO ≥ COLLATERAL_OUTPUT_LOVELACE (for collateral) AND a
+  // distinct clean ADA-only UTxO ≥ FEE_OUTPUT_LOVELACE (for the fee
+  // input). One UTxO can't fill both slots: regular `inputs` and
+  // `collateral` are separate fields and share-via-double-spending is
+  // rejected by the ledger.
+  const cleanAdminUtxos = adminUtxos
+    .filter((u) => !u[1].value.assets || u[1].value.assets.size === 0)
+    .sort((a, b) => Number((b[1].value.coins ?? 0n) - (a[1].value.coins ?? 0n)));
+  const hasCollateralReady = cleanAdminUtxos.some((u) => (u[1].value.coins ?? 0n) >= COLLATERAL_OUTPUT_LOVELACE);
+  const hasFeeAndCollateralPair = cleanAdminUtxos.length >= 2
+    && (cleanAdminUtxos[0][1].value.coins ?? 0n) >= COLLATERAL_OUTPUT_LOVELACE
+    && (cleanAdminUtxos[1][1].value.coins ?? 0n) >= FEE_OUTPUT_LOVELACE;
+  if (hasCollateralReady && hasFeeAndCollateralPair) {
     return null;
   }
-
-  const needed = targetLovelace - adminBalance;
 
   // Find a script address to source funds from — use the first settings handle's address
   const settingsHandleName = "demi@handle_settings";
@@ -648,22 +699,52 @@ export const buildPreparationTx = async ({
     throw new Error("no clean UTxOs at script address to fund admin wallet");
   }
 
-  const output: CardanoTypes.TxOut = {
-    address: asPaymentAddress(adminAddress),
-    value: { coins: needed },
+  // Two outputs: index 0 = collateral, index 1 = fee. Index assignment
+  // must match what the migration tx assumes when it builds chained
+  // input refs from the funding tx hash.
+  const adminPaymentAddress = asPaymentAddress(adminAddress);
+  const collateralOutput: CardanoTypes.TxOut = {
+    address: adminPaymentAddress,
+    value: { coins: COLLATERAL_OUTPUT_LOVELACE },
+  };
+  const feeOutput: CardanoTypes.TxOut = {
+    address: adminPaymentAddress,
+    value: { coins: FEE_OUTPUT_LOVELACE },
   };
 
   const nativeScript = nativeScriptCborHex ? parseNativeScript(nativeScriptCborHex) : undefined;
 
-  return buildAndSerializeTx({
+  const built = await buildAndSerializeTx({
     selectedUtxos: [],
     remainingUtxos: cleanUtxos,
-    requestedOutputs: [output],
+    requestedOutputs: [collateralOutput, feeOutput],
     changeAddress: scriptAddress,
     buildContext,
     nativeScript,
     excludeUtxoRefs,
   });
+
+  // Synthesize the predicted UTxOs the funding tx will create at admin.
+  // These don't exist on chain yet — `txHash` is the body hash of the
+  // unsigned tx, identical post-signing because Eternl only adds
+  // witnesses (which don't affect body hash).
+  const fundingTxId = Cardano.TransactionId(built.txHash as HexBlob);
+  const adminAddressTyped = adminPaymentAddress as unknown as CardanoTypes.TxOut["address"];
+  const pendingAdminFundingUtxos: PendingAdminFundingUtxos = {
+    collateralUtxo: [
+      { txId: fundingTxId, index: 0, address: adminAddressTyped },
+      { address: adminAddressTyped, value: { coins: COLLATERAL_OUTPUT_LOVELACE } },
+    ],
+    feeUtxo: [
+      { txId: fundingTxId, index: 1, address: adminAddressTyped },
+      { address: adminAddressTyped, value: { coins: FEE_OUTPUT_LOVELACE } },
+    ],
+  };
+
+  return {
+    ...built,
+    pendingAdminFundingUtxos,
+  };
 };
 
 /**
@@ -680,12 +761,22 @@ export const buildMptRootMigrationTx = async ({
   oldValidatorCborHex,
   blockfrostApiKey,
   userAgent,
+  pendingAdminFunding,
 }: {
   desired: DesiredDeploymentState;
   newMptRootHash: string;
   oldValidatorCborHex: string;
   blockfrostApiKey: string;
   userAgent: string;
+  /**
+   * When set, the migration tx skips Blockfrost lookups for admin's
+   * UTxOs and uses the predicted outputs of an unconfirmed
+   * `buildPreparationTx` instead. The funding tx must be submitted
+   * before this one (manifest order is enforced by the operator
+   * runbook); the node accepts the chain because the funding tx
+   * lands first and creates the inputs this tx then consumes.
+   */
+  pendingAdminFunding?: PendingAdminFundingUtxos;
 }): Promise<BuiltTransaction> => {
   const isMainnet = desired.network === "mainnet";
   const adminKeyHash = desired.buildParameters.adminVerificationKeyHash;
@@ -746,15 +837,31 @@ export const buildMptRootMigrationTx = async ({
   )
     .toAddress()
     .toBech32() as string;
-  const adminUtxos = await fetchBlockfrostUtxos(
-    adminAddressBech32,
-    blockfrostApiKey,
-    desired.network,
-  );
-  const cleanUtxos = adminUtxos.filter((u) => !u[1].value.assets || u[1].value.assets.size === 0);
-  const collateralUtxo = cleanUtxos.length > 0
-    ? cleanUtxos.sort((a, b) => Number((b[1].value.coins ?? 0n) - (a[1].value.coins ?? 0n)))[0]
-    : undefined;
+  // Resolve admin UTxOs for fee + collateral. When the planner has
+  // emitted a chained `buildPreparationTx`, those outputs aren't on
+  // chain yet — use the predicted UTxOs the planner returned, and
+  // skip the Blockfrost lookup entirely. Otherwise fall back to the
+  // existing on-chain UTxO query (admin already has funds, so the
+  // planner didn't emit a funding tx).
+  let walletUtxosForMigration: CardanoTypes.Utxo[];
+  let collateralUtxo: CardanoTypes.Utxo | undefined;
+  if (pendingAdminFunding) {
+    walletUtxosForMigration = [pendingAdminFunding.feeUtxo];
+    collateralUtxo = pendingAdminFunding.collateralUtxo;
+  } else {
+    const adminUtxos = await fetchBlockfrostUtxos(
+      adminAddressBech32,
+      blockfrostApiKey,
+      desired.network,
+    );
+    const cleanUtxos = adminUtxos.filter((u) => !u[1].value.assets || u[1].value.assets.size === 0);
+    const sortedClean = cleanUtxos.sort((a, b) => Number((b[1].value.coins ?? 0n) - (a[1].value.coins ?? 0n)));
+    collateralUtxo = sortedClean[0];
+    // Fee inputs come from admin's full UTxO set (assets included —
+    // the input selector will pick what it needs and route any
+    // non-ADA assets back to admin via change).
+    walletUtxosForMigration = adminUtxos;
+  }
 
   const spendInput: CardanoTypes.Utxo = [
     {
@@ -805,7 +912,7 @@ export const buildMptRootMigrationTx = async ({
   const result = await buildPlutusSpendTxInline({
     buildContext,
     spendInput,
-    walletUtxos: adminUtxos,
+    walletUtxos: walletUtxosForMigration,
     collateralUtxo,
     output: migrationOutput,
     spendRedeemer,
@@ -819,6 +926,7 @@ export const buildMptRootMigrationTx = async ({
     cborHex: result.cborHex,
     estimatedSignedTxSize,
     consumedInputs: result.consumedInputs,
+    txHash: result.txHash,
   };
 };
 
@@ -847,7 +955,7 @@ const buildPlutusSpendTxInline = async ({
   attachedPlutusScript: CardanoTypes.Script;
   requiredSigner: string;
   changeAddress: string;
-}): Promise<{ cborHex: string; consumedInputs: Set<string> }> => {
+}): Promise<{ cborHex: string; consumedInputs: Set<string>; txHash: string }> => {
   const changeAddressBech32 = asPaymentAddress(changeAddress);
   const inputSelector = roundRobinRandomImprove({
     changeAddressResolver: {
@@ -923,7 +1031,8 @@ const buildPlutusSpendTxInline = async ({
   for (const u of selection.selection.inputs) {
     consumedInputs.add(`${u[0].txId}#${u[0].index}`);
   }
-  return { cborHex, consumedInputs };
+  const txHash = String(unsignedTx.id);
+  return { cborHex, consumedInputs, txHash };
 };
 
 const buildPlutusTxForSelection = (


### PR DESCRIPTION
## Summary
- Chains the MPT-migration tx directly onto an admin-funding tx-00 in the same workflow run, so the operator signs everything in one Eternl session and submits in manifest order. The historical two-phase pattern (sign phase 1, wait for funding to confirm, re-run workflow for phase 2) is gone.
- The funding tx now emits TWO outputs at admin (6 ADA collateral + 4 ADA fee) because the Cardano ledger requires the regular-`inputs` and `collateral` fields to point at distinct UTxOs. The migration tx references those outputs by predicted txid + index 0/1.
- `BuiltTransaction` gains `txHash: string` (deterministic body hash, identical post-signing) so callers can build chained input refs without waiting for confirmation.

## Why this works without a Cardano protocol change
Cardano's mempool accepts a tx that consumes an output from another in-mempool / not-yet-confirmed tx, as long as both land in the same chain in order. Submitted in manifest order (tx-00 → tx-NN-mpt-migration), the funding tx lands first, creates the inputs, and the migration tx then consumes them. The body hash of the funding tx is computed from the unsigned body — Eternl signing only adds witnesses, which never change the body hash — so the migration tx's input refs are stable.

## Why two outputs at admin instead of one
The cutover doc's old admin-funding tx emitted ONE 10 ADA output. Worked for a two-phase signing because the migration tx was built in phase 2 and could split admin's UTxOs at will. For the chained pattern, the migration tx needs both a regular fee input AND a collateral input, and the ledger rejects re-using the same UTxO ref in both slots (would be double-spending in the failure case). Splitting funding into two outputs (6 + 4 ADA, total still 10) gives the migration tx two distinct UTxOs to point at.

The 6 ADA collateral floor is well above the 5 ADA collateral threshold the cutover doc calls out. The 4 ADA fee output covers the migration tx fee (a few hundred thousand lovelace) plus a comfortable change buffer.

## Why short-circuit when admin has the right UTxOs already
`buildPreparationTx` returns null (no funding tx) when admin already has BOTH a clean ADA-only UTxO ≥ 6 ADA AND a separate clean ADA-only UTxO ≥ 4 ADA. That means an operator who pre-funded admin manually (e.g. before mainnet cutover for risk-aversion reasons) gets the existing on-chain Blockfrost-lookup path for the migration tx — no chained inputs, no tx-00, no behavioral change.

## What changed

### `src/deploymentTx.ts`
- `BuiltTransaction.txHash: string` — new field, populated by every tx builder.
- `PendingAdminFundingUtxos` interface — `{ collateralUtxo, feeUtxo }`, predicted UTxOs the funding tx will create at admin.
- `PreparationTx extends BuiltTransaction` with `pendingAdminFundingUtxos`.
- `buildPreparationTx` rewritten to: split outputs (6/4 ADA), short-circuit when admin already has the right pair, return synthesized predicted UTxOs.
- `buildMptRootMigrationTx` accepts optional `pendingAdminFunding`. When set: walletUtxos = `[feeUtxo]`, collateralUtxo = `collateralUtxo`. When unset: existing Blockfrost path.

### `scripts/generateDeploymentPlan.ts`
- `mptNeedsMigration` check hoisted above the deploy-tx loop.
- `buildPreparationTx` runs FIRST when migration is needed; emits `tx-00-admin-funding.cbor`.
- Migration-tx emission passes `pendingAdminFunding` through.
- Deferred-migration fallback (the "re-run this workflow" branch) deleted — chained submission means the migration tx always builds successfully when funding is available.

## Test plan
- [x] `npx tsc --noEmit` — type-check passes.
- [x] `npm test` — 35/35 vitest pass (no behavioral regression in plan / contract / cbor / deployment-state suites).
- [x] `npm run lint` — eslint clean (max-warnings=0). Aiken fmt skipped locally due to libssl.so.1.1 environment gap; CI runs it.
- [ ] **Preprod rehearsal (post-merge integration test):** trigger the deployment-plan workflow with the preprod admin wallet deliberately emptied. Expected manifest: `tx-00-admin-funding.cbor` + `tx-01..tx-N` deploys + `tx-{N+1}-mpt-migration.cbor`. Operator signs in order in Eternl; submits sequentially; node accepts the chain (funding lands first, migration's chained input refs resolve, both confirm). Validates the `txHash` body-hash prediction is correct and the SDK doesn't reorder outputs.
- [ ] **Mainnet cutover (later, deliberately gated on operator approval):** the new chained pattern lets the mainnet cutover happen in a single signing ceremony rather than two.

## Cross-repo coordination
- This PR touches `decentralized-minting` only — no `adahandle-deployments` changes.
- A follow-up PR in `adahandle-deployments` updates [`docs/demi-mainnet-cutover.md`](https://github.com/koralabs/adahandle-deployments/blob/master/docs/demi-mainnet-cutover.md) § Admin Wallet Collateral Underflow with an Automation note describing this change and pointing operators at the new `tx-00`-first manifest. (Stashed for follow-up — would have bundled poorly into the in-flight P2d PR which is the only other adahandle-deployments PR open.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)