### PR TITLE
Load persisted MPT store root before mint prep

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,11 +1,36 @@
 import { Store, Trie } from "@aiken-lang/merkle-patricia-forestry";
 import fs from "fs/promises";
 
-const init = async (folder: string): Promise<Trie> => {
-  const db = new Trie(new Store(folder));
+const isMissingStoreRoot = (error: unknown): boolean => {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+
+  return (
+    code === "LEVEL_NOT_FOUND" ||
+    (error instanceof Error && error.message.includes("NotFound"))
+  );
+};
+
+const createEmptyTrie = async (store: Store): Promise<Trie> => {
+  const db = new Trie(store);
   // @ts-expect-error: Library issue
   await db.save();
   return db;
+};
+
+const init = async (folder: string): Promise<Trie> => {
+  const store = new Store(folder);
+  await store.ready();
+
+  try {
+    const db = (await Trie.load(store)) as Trie;
+    return db.isEmpty() ? createEmptyTrie(store) : db;
+  } catch (error) {
+    if (!isMissingStoreRoot(error)) throw error;
+    return createEmptyTrie(store);
+  }
 };
 
 const inspect = async (db: Trie) => {
@@ -20,7 +45,7 @@ const clear = async (folder: string) => {
 const fillHandles = async (
   db: Trie,
   handles: string[],
-  progress: () => void
+  progress: () => void,
 ) => {
   for (const handle of handles) {
     await db.insert(handle, "");
@@ -42,7 +67,7 @@ const removeHandle = async (db: Trie, key: string) => {
 const printProof = async (
   db: Trie,
   key: string,
-  format: "json" | "cborHex"
+  format: "json" | "cborHex",
 ) => {
   const proof = await db.prove(key);
   switch (format) {

--- a/tests/store.persistence.test.ts
+++ b/tests/store.persistence.test.ts
@@ -1,0 +1,55 @@
+import { execFile } from "child_process";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { promisify } from "util";
+
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+const runStoreScript = async (folder: string, script: string): Promise<string> => {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ["--import", "tsx", "--eval", script],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, STORE_FOLDER: folder },
+    },
+  );
+  return stdout.trim();
+};
+
+describe("store persistence", () => {
+  it("reopens the saved trie root instead of starting from an empty root", async () => {
+    const folder = await fs.mkdtemp(path.join(os.tmpdir(), "demi-mpt-"));
+
+    try {
+      const savedHash = await runStoreScript(
+        folder,
+        `
+          import { init } from "./src/store/index.ts";
+
+          const db = await init(process.env.STORE_FOLDER);
+          await db.insert("alice", "");
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          console.log(db.hash.toString("hex"));
+        `,
+      );
+
+      const reopenedHash = await runStoreScript(
+        folder,
+        `
+          import { init } from "./src/store/index.ts";
+
+          const db = await init(process.env.STORE_FOLDER);
+          console.log(db.hash.toString("hex"));
+        `,
+      );
+
+      expect(reopenedHash).toBe(savedHash);
+    } finally {
+      await fs.rm(folder, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/store.unit.test.ts
+++ b/tests/store.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 describe("store helpers", () => {
-  it("initializes, mutates, and clears trie store", async () => {
+  it("loads an existing trie store before mutating it", async () => {
     vi.resetModules();
 
     const saveMock = vi.fn().mockResolvedValue(undefined);
@@ -11,11 +11,20 @@ describe("store helpers", () => {
       toJSON: () => ({ ok: true }),
       toCBOR: () => Buffer.from("abcd", "hex"),
     });
-    const trieLoadMock = vi.fn().mockResolvedValue({ loaded: true });
+    const loadedTrie = {
+      hash: Buffer.from("11".repeat(32), "hex"),
+      isEmpty: vi.fn().mockReturnValue(false),
+      save: saveMock,
+      insert: insertMock,
+      delete: deleteMock,
+      prove: proveMock,
+    };
+    const trieLoadMock = vi.fn().mockResolvedValue(loadedTrie);
     const rmMock = vi.fn().mockResolvedValue(undefined);
 
     class MockStore {
       folder: string;
+      ready = vi.fn().mockResolvedValue(undefined);
       constructor(folder: string) {
         this.folder = folder;
       }
@@ -27,6 +36,7 @@ describe("store helpers", () => {
         this.hash = Buffer.alloc(32);
       }
       static load = trieLoadMock;
+      isEmpty = vi.fn().mockReturnValue(true);
       save = saveMock;
       insert = insertMock;
       delete = deleteMock;
@@ -55,7 +65,9 @@ describe("store helpers", () => {
     } = await import("../src/store/index.js");
 
     const db = await init("./tmp-db");
-    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(trieLoadMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).not.toHaveBeenCalled();
+    expect(db).toBe(loadedTrie);
 
     await inspect(db as never);
     expect(logSpy).toHaveBeenCalled();
@@ -77,5 +89,44 @@ describe("store helpers", () => {
 
     await clear("./tmp-db");
     expect(rmMock).toHaveBeenCalledWith("./tmp-db", { recursive: true });
+  });
+
+  it("creates an empty trie when the store has no saved root", async () => {
+    vi.resetModules();
+
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    const trieLoadMock = vi.fn().mockRejectedValue(
+      Object.assign(new Error("NotFound"), { code: "LEVEL_NOT_FOUND" }),
+    );
+
+    class MockStore {
+      folder: string;
+      ready = vi.fn().mockResolvedValue(undefined);
+      constructor(folder: string) {
+        this.folder = folder;
+      }
+    }
+
+    class MockTrie {
+      hash: Buffer;
+      constructor(_store: MockStore) {
+        this.hash = Buffer.alloc(32);
+      }
+      static load = trieLoadMock;
+      isEmpty = vi.fn().mockReturnValue(true);
+      save = saveMock;
+    }
+
+    vi.doMock("@aiken-lang/merkle-patricia-forestry", () => ({
+      Store: MockStore,
+      Trie: MockTrie,
+    }));
+
+    const { init } = await import("../src/store/index.js");
+
+    const db = await init("./tmp-db");
+    expect(trieLoadMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(db.hash.toString("hex")).toBe(Buffer.alloc(32).toString("hex"));
   });
 });


### PR DESCRIPTION
Fixes the minting trie producer path by loading the saved MPT root from the on-disk Store in src/store/index.ts instead of always creating an empty Trie for the same folder. This prevents valid current-chain state from being compared against an empty local root during prepareNewMintTransaction and related mint-data verification paths. Regression coverage now checks both the mocked helper behavior and a real persisted store reopen. Verify: npm test passed (14 files, 81 tests).