### PR TITLE
chore(store): rip out disk trie cache — handle MPT is API-only sourced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,19 @@
 
 ## Master AGENTS.md
 - [REQUIREMENT] Read the AGENTS.md in this project's parent folder for complete instructions and inter-project references
+
+## DESIGN LAW — Handle MPT is API-only sourced, NEVER disk-cached
+The Merkle Patricia Trie of minted handles is **always rebuilt fresh,
+in-memory, from the handle registry API on every invocation**, verified
+against the on-chain root, and **never persisted to or loaded from local
+disk**. The on-chain root (read via the API) is the only source of truth; the
+engine runs in a Lambda where a local `/tmp` cache is ephemeral, drift-prone,
+and worse than no cache. If the API is unreachable, **abort the mint** — there
+is no local fallback.
+
+Do **not** add a disk-backed `Store(folder)` or `fs` persistence to
+`src/store/index.ts`, and do not "fix" code toward loading the trie from disk.
+A self-fix (PR #43, denied) once tried exactly that against dead code — see
+[`docs/spec/mpt-trie-sourcing.md`](./docs/spec/mpt-trie-sourcing.md) for the
+full law, the production path (`minting.handle.me` `verifyRootHash` /
+`buildApiRootTrie`), and the CI guard in `tests/store.unit.test.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+Read [`AGENTS.md`](./AGENTS.md) first (and the master AGENTS.md in the parent
+folder). The points below are load-bearing rules for this repo.
+
+## DESIGN LAW — Handle MPT is API-only sourced, NEVER disk-cached
+
+The Merkle Patricia Trie of minted handles is **always rebuilt fresh,
+in-memory, from the handle registry API on every invocation**, verified
+against the on-chain root, and **never persisted to or loaded from local
+disk**.
+
+- The on-chain root (read via the API) is the **only** source of truth. A
+  local on-disk trie is a second copy that can silently drift from it.
+- The minting engine runs in a **Lambda**. Local disk (`/tmp`) is ephemeral
+  and survives unpredictably across warm invocations — a disk cache is both
+  useless and a correctness hazard. A cache that "sometimes persists" is worse
+  than none.
+- If the API is unreachable, **abort the mint**. There is no local fallback.
+
+**Do not** reintroduce a disk-backed `Store(folder)` or `fs` persistence into
+`src/store/index.ts`, and do not "repair" code toward loading the trie from
+disk. An automated self-fix (PR #43, denied 2026-06-07) did exactly that —
+against dead code production never called — fixing nothing real and
+entrenching the cache pattern this law forbids.
+
+References:
+- Full spec: [`docs/spec/mpt-trie-sourcing.md`](./docs/spec/mpt-trie-sourcing.md)
+- Production build: `minting.handle.me` → `verifyRootHash` / `buildApiRootTrie`
+  (`Trie.fromList` over the `/handles` API), then the engine's hard root check
+  in `src/txs/prepareNewMint.ts`.
+- CI guard: `tests/store.unit.test.ts` fails if disk `Store` / `fs` coupling
+  returns to `src/store/index.ts`.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -3,4 +3,5 @@
 - [Technical Spec](./spec.md)
 - [Contract Deployment Pipeline](./contract-deployment-pipeline.md)
 - [Data Model](./data-model.md)
+- [Handle MPT Trie Sourcing (API-only, never disk-cached)](./mpt-trie-sourcing.md)
 - [Aiken Cost Baseline & Optimization Step](./aiken-cost-baseline.md)

--- a/docs/spec/mpt-trie-sourcing.md
+++ b/docs/spec/mpt-trie-sourcing.md
@@ -1,0 +1,59 @@
+# Handle MPT Trie Sourcing — API-only, never disk-cached
+
+**Design law:** the Merkle Patricia Trie (MPT) of minted handles is **always
+rebuilt fresh, in-memory, from the handle registry API on every invocation**,
+verified against the on-chain root before use, and **never persisted to or
+loaded from local disk**.
+
+This is a hard rule, not a preference. It must not be "optimized" into a disk
+cache.
+
+## Why no disk cache
+
+- **The on-chain root is the only source of truth.** The authoritative MPT
+  root lives on-chain and is read via the API (`mpt_root_hash` /
+  `datum_mpt_root_hash`). Any local on-disk copy of the trie is a *second
+  copy* that can silently drift from it.
+- **The engine runs in a Lambda.** Local disk (`/tmp`) is ephemeral and
+  survives *unpredictably* across warm invocations. A disk cache is therefore
+  both **useless** (cold starts see nothing) and a **correctness hazard** (a
+  warm container can load a stale root). A cache that "sometimes persists" is
+  worse than no cache at all — it manufactures drift while looking like
+  persistence.
+- **Rebuilding is cheap relative to the failure mode.** Re-fetching the
+  handle set and building the trie costs far less than minting against stale
+  state. If the API is unreachable, **abort the mint** — there is no fallback
+  to a local copy.
+
+## How it actually works (production)
+
+1. **`minting.handle.me` → `verifyRootHash()`**
+   (`src/helpers/legacyMinting/utils.ts`): fetches the API root + the on-chain
+   `datum_mpt_root_hash`, and throws `RootHashMismatchError` (aborts the mint)
+   if they disagree.
+2. **`buildApiRootTrie()`**: fetches all handles via the API `/handles`
+   endpoint (`fetchHandlesApiTextPaginated`) and builds the trie in-memory with
+   `Trie.fromList(...)`. No disk `Store`.
+3. The built `db: Trie` is handed to the engine
+   (`decentralized-minting` → `prepareNewMintTransaction`), which **hard-errors
+   on `"Local DB and On Chain Root Hash mismatch"`** (`src/txs/prepareNewMint.ts`)
+   before it will build any mint proofs.
+
+The SDK helper `buildTrie(handles)` in `src/store/index.ts` mirrors this
+in-memory construction (`Trie.fromList`) for CLI / SDK consumers.
+
+## Guardrails
+
+- `src/store/index.ts` carries the DESIGN LAW as a header comment and contains
+  **no `Store(folder)` / `fs`** coupling.
+- `tests/store.unit.test.ts` has a CI guard that **fails the build** if a disk
+  `Store` or `fs` import is reintroduced into `src/store/index.ts`.
+
+## History
+
+The disk-`Store` path (`init(folder)`, `clear(folder)`) was removed
+2026-06-07. It was dead code — production never called it — but an automated
+self-fix (PR #43) "repaired" its empty-trie behaviour and tried to merge a
+disk-load path into the engine. That fixed dead code and entrenched exactly
+the cache pattern this law forbids. The PR was denied; the disk path was
+removed so it can't be mistaken for a real persistence layer again.

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,26 +1,61 @@
-import { Store, Trie } from "@aiken-lang/merkle-patricia-forestry";
-import fs from "fs/promises";
+import { Trie } from "@aiken-lang/merkle-patricia-forestry";
 
-const init = async (folder: string): Promise<Trie> => {
-  const db = new Trie(new Store(folder));
-  // @ts-expect-error: Library issue
-  await db.save();
-  return db;
-};
+/**
+ * DESIGN LAW — the handle MPT is API-only sourced, NEVER disk-cached.
+ *
+ * The Merkle Patricia Trie of minted handles is ALWAYS rebuilt fresh,
+ * in-memory, from the handle registry API on every invocation, and verified
+ * against the on-chain root before use. The engine hard-errors on
+ * "Local DB and On Chain Root Hash mismatch" (see src/txs/prepareNewMint.ts)
+ * precisely so a wrong local trie can never be minted against. The trie is
+ * NEVER persisted to, nor loaded from, local disk.
+ *
+ * Why no disk cache:
+ *  - The on-chain root (read via the API) is the ONLY source of truth. Any
+ *    local on-disk copy is a second copy that can silently drift from it.
+ *  - The minting engine runs in a Lambda. Local disk (/tmp) is ephemeral and
+ *    survives unpredictably across warm invocations — so a disk cache is both
+ *    useless (cold starts see nothing) AND a correctness hazard (a warm
+ *    container can load a stale root). A cache that "sometimes persists" is
+ *    worse than no cache at all.
+ *  - Rebuilding from the API is cheap relative to the cost of minting against
+ *    stale state. If the API is unreachable, ABORT the mint — there is no
+ *    fallback to a local copy.
+ *
+ * Canonical production build: minting.handle.me `verifyRootHash` /
+ * `buildApiRootTrie` — fetch all handles via the `/handles` endpoint and
+ * `Trie.fromList(...)`, then verify the computed root equals the on-chain
+ * `mpt_root_hash`. `buildTrie` below mirrors that in-memory construction for
+ * SDK/CLI consumers.
+ *
+ * Do NOT reintroduce a disk-backed `Store(folder)` (or `fs`) here. The
+ * disk-`Store` path was removed 2026-06-07 after an automated self-fix
+ * (PR #43) tried to "repair" a disk-load branch that production never called
+ * — fixing dead code and entrenching the very cache pattern this law forbids.
+ * The `tests/store.unit.test.ts` guard fails CI if disk coupling returns.
+ */
+
+/**
+ * Build the handle MPT in-memory from a handle list (API-sourced). Mirrors
+ * the production `buildApiRootTrie` (`Trie.fromList`). No disk Store.
+ */
+const buildTrie = async (handles: string[]): Promise<Trie> =>
+  Trie.fromList(handles.map((handle) => ({ key: handle, value: "" })));
 
 const inspect = async (db: Trie) => {
   // console.log(db.hash?.toString("hex") || Buffer.alloc(32).toString("hex"));
   console.log(db);
 };
 
-const clear = async (folder: string) => {
-  await fs.rm(folder, { recursive: true });
-};
-
+/**
+ * Incremental in-memory insert helper (CLI / debug). The canonical full-set
+ * build is `buildTrie` / `Trie.fromList`; prefer it for constructing the
+ * whole handle trie. Operates on whatever in-memory `Trie` is passed.
+ */
 const fillHandles = async (
   db: Trie,
   handles: string[],
-  progress: () => void
+  progress: () => void,
 ) => {
   for (const handle of handles) {
     await db.insert(handle, "");
@@ -42,7 +77,7 @@ const removeHandle = async (db: Trie, key: string) => {
 const printProof = async (
   db: Trie,
   key: string,
-  format: "json" | "cborHex"
+  format: "json" | "cborHex",
 ) => {
   const proof = await db.prove(key);
   switch (format) {
@@ -55,12 +90,4 @@ const printProof = async (
   }
 };
 
-export {
-  addHandle,
-  clear,
-  fillHandles,
-  init,
-  inspect,
-  printProof,
-  removeHandle,
-};
+export { addHandle, buildTrie, fillHandles, inspect, printProof, removeHandle };

--- a/src/txs/prepareNewMint.ts
+++ b/src/txs/prepareNewMint.ts
@@ -127,6 +127,12 @@ const prepareNewMintTransaction = async (
   const { handlePriceInfo, handlePriceInfoUtxo } =
     handlePriceInfoDataResult.data;
 
+  // Consensus gate: the caller-supplied `db` trie MUST be built fresh from
+  // the API (in-memory) and match the on-chain root. The on-chain
+  // `mpt_root_hash` is the only source of truth — there is NO disk cache of
+  // the trie (see src/store/index.ts DESIGN LAW; the engine runs in a Lambda
+  // where a local cache would silently drift). If they don't match, the trie
+  // is stale/wrong and we abort rather than mint against it.
   if (
     mintingData.mpt_root_hash.toLowerCase() !==
     (db.hash?.toString("hex") || Buffer.alloc(32).toString("hex")).toLowerCase()

--- a/tests/store.unit.test.ts
+++ b/tests/store.unit.test.ts
@@ -1,81 +1,74 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 
-describe("store helpers", () => {
-  it("initializes, mutates, and clears trie store", async () => {
+describe("store helpers (in-memory, API-sourced — no disk)", () => {
+  it("builds the trie from a handle list and mutates/proves in memory", async () => {
     vi.resetModules();
 
-    const saveMock = vi.fn().mockResolvedValue(undefined);
     const insertMock = vi.fn().mockResolvedValue(undefined);
     const deleteMock = vi.fn().mockResolvedValue(undefined);
     const proveMock = vi.fn().mockResolvedValue({
       toJSON: () => ({ ok: true }),
       toCBOR: () => Buffer.from("abcd", "hex"),
     });
-    const trieLoadMock = vi.fn().mockResolvedValue({ loaded: true });
-    const rmMock = vi.fn().mockResolvedValue(undefined);
-
-    class MockStore {
-      folder: string;
-      constructor(folder: string) {
-        this.folder = folder;
-      }
-    }
+    // The built trie is whatever `Trie.fromList` returns — purely in-memory.
+    const builtTrie = {
+      insert: insertMock,
+      delete: deleteMock,
+      prove: proveMock,
+    };
+    const fromListMock = vi.fn().mockResolvedValue(builtTrie);
 
     class MockTrie {
-      hash: Buffer;
-      constructor(_store: MockStore) {
-        this.hash = Buffer.alloc(32);
-      }
-      static load = trieLoadMock;
-      save = saveMock;
-      insert = insertMock;
-      delete = deleteMock;
-      prove = proveMock;
+      static fromList = fromListMock;
     }
 
     vi.doMock("@aiken-lang/merkle-patricia-forestry", () => ({
-      Store: MockStore,
       Trie: MockTrie,
-    }));
-    vi.doMock("fs/promises", () => ({
-      default: {
-        rm: rmMock,
-      },
     }));
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const {
-      addHandle,
-      clear,
-      fillHandles,
-      init,
-      inspect,
-      printProof,
-      removeHandle,
-    } = await import("../src/store/index.js");
+    const { addHandle, buildTrie, fillHandles, inspect, printProof, removeHandle } =
+      await import("../src/store/index.js");
 
-    const db = await init("./tmp-db");
-    expect(saveMock).toHaveBeenCalledTimes(1);
+    // buildTrie is API-only sourced: `Trie.fromList` over {key,value} pairs,
+    // never a disk `Store`.
+    const db = await buildTrie(["a", "b"]);
+    expect(fromListMock).toHaveBeenCalledWith([
+      { key: "a", value: "" },
+      { key: "b", value: "" },
+    ]);
 
     await inspect(db as never);
     expect(logSpy).toHaveBeenCalled();
 
     const progress = vi.fn();
-    await fillHandles(db as never, ["a", "b"], progress);
+    await fillHandles(db as never, ["c", "d"], progress);
     expect(insertMock).toHaveBeenCalledTimes(2);
     expect(progress).toHaveBeenCalledTimes(2);
 
-    await addHandle(db as never, "c", "value");
-    expect(insertMock).toHaveBeenCalledWith("c", "value");
+    await addHandle(db as never, "e", "value");
+    expect(insertMock).toHaveBeenCalledWith("e", "value");
 
-    await removeHandle(db as never, "c");
-    expect(deleteMock).toHaveBeenCalledWith("c");
+    await removeHandle(db as never, "e");
+    expect(deleteMock).toHaveBeenCalledWith("e");
 
     await printProof(db as never, "a", "json");
     await printProof(db as never, "a", "cborHex");
     expect(proveMock).toHaveBeenCalledTimes(2);
+  });
 
-    await clear("./tmp-db");
-    expect(rmMock).toHaveBeenCalledWith("./tmp-db", { recursive: true });
+  it("source has NO disk-backed Store or fs coupling (API-only law guard)", () => {
+    // Enforces the design law in CI: the handle MPT is built in-memory from
+    // the API, never persisted to / loaded from disk. If a disk `Store` or
+    // `fs` import is reintroduced into store/index.ts (as automated self-fix
+    // PR #43 attempted), this fails — "this should not happen again."
+    const srcPath = fileURLToPath(
+      new URL("../src/store/index.ts", import.meta.url),
+    );
+    const src = readFileSync(srcPath, "utf8");
+    expect(src).not.toMatch(/new Store\(/);
+    expect(src).not.toMatch(/from ["']fs/);
   });
 });


### PR DESCRIPTION
## What & why

The handle MPT is — and must remain — **built fresh in-memory from the API on every invocation**, verified against the on-chain root, and **never persisted to or loaded from local disk**.

Production already works exactly this way:
- `minting.handle.me` → `verifyRootHash()` fetches the API root + on-chain `datum_mpt_root_hash`, throws `RootHashMismatchError` (aborts the mint) if they disagree, then `buildApiRootTrie()` builds the trie in-memory via `fetchHandlesApiTextPaginated('/handles')` + `Trie.fromList(...)`.
- This engine then hard-errors on `"Local DB and On Chain Root Hash mismatch"` (`src/txs/prepareNewMint.ts`) before building any proofs.

The **only** disk-backed code was `src/store/index.ts` (`init(folder)` / `clear(folder)` over `new Trie(new Store(folder))`) — **dead code no production path ever called**, exercised only by its unit test. An automated self-fix (PR #43) "repaired" its empty-trie clobber and tried to merge a disk-**load** path into the engine — fixing dead code **and** entrenching the exact cache pattern that's forbidden here. The engine runs in a **Lambda**, where a local `/tmp` trie is ephemeral, drift-prone across warm invocations, and worse than no cache.

## Changes
- **`src/store/index.ts`** — remove `Store`/`fs`, `init(folder)`, `clear(folder)`. Replace disk `init` with in-memory `buildTrie(handles)` (`Trie.fromList`, mirroring production). Add the **DESIGN LAW** as a header comment.
- **`tests/store.unit.test.ts`** — test the in-memory helpers; add a **CI guard that fails** if a disk `Store`/`fs` import returns to `store/index.ts` ("this should not happen again").
- **`src/txs/prepareNewMint.ts`** — comment the on-chain root gate as the consensus check against a fresh API-built trie.
- **Docs** — `docs/spec/mpt-trie-sourcing.md` (+ spec index link), `AGENTS.md`, `CLAUDE.md` document the API-only law and the denied-PR history.

## Verification
- `npm test` → 80 passing (13 files)
- `npm run build` (tsc) → clean
- No production path imports the removed `init`/`clear`.

Supersedes / motivates closing **#43** (which fixed the dead disk path and is the anti-pattern this PR removes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)